### PR TITLE
Renamed variables to match NGS API and fixed gradle build

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="jbr-11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Embedded JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Embedded JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/locoquest/app/MainActivity.kt
+++ b/app/src/main/java/com/locoquest/app/MainActivity.kt
@@ -383,7 +383,7 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback {
                                     )
                                 )
                                 .title(benchmark.name)
-                                .snippet("PID: ${benchmark.pid}\nOrtho Height: ${benchmark.orthoHeight}")
+                                .snippet("PID: ${benchmark.pid}\nOrtho Height: ${benchmark.orthoHt}")
                             Handler(Looper.getMainLooper()).post { map.addMarker(marker) }
                         }
                     } else {

--- a/app/src/main/java/com/locoquest/app/dto/Benchmark.kt
+++ b/app/src/main/java/com/locoquest/app/dto/Benchmark.kt
@@ -1,22 +1,16 @@
 package com.locoquest.app.dto
-
 import androidx.room.Entity
-
 @Entity(tableName="benchmark")
 data class Benchmark(
     val pid: String,
     val name: String,
     val lat: String,
     val lon: String,
-    val ellipseHeight: String,
+    val ellipHeight: String,
     val posDatum: String,
     val posSource: String,
     val posOrder: String,
-    val orthoHeight: String,
+    val orthoHt: String,
     val vertDatum: String,
     val vertSource: String,
-    val vertOrder: String, )
-
-
-
-
+    val vertOrder: String )

--- a/app/src/main/java/com/locoquest/app/dto/LocationDetails.kt
+++ b/app/src/main/java/com/locoquest/app/dto/LocationDetails.kt
@@ -1,13 +1,11 @@
-package com.locoquest.app.dto
-
 data class LocationDetails(
     val lat: String,
     val lon: String,
-    val ellipseHeight: String,
+    val ellipHeight: String,
     val posDatum: String,
     val posSource: String,
     val posOrder: String,
-    val orthoHeight: String,
+    val orthoHt: String,
     val vertDatum: String,
     val vertSource: String,
     val vertOrder: String

--- a/app/src/test/java/com/locoquest/app/BenchmarkUnitTests.kt
+++ b/app/src/test/java/com/locoquest/app/BenchmarkUnitTests.kt
@@ -28,11 +28,11 @@ class BenchmarkServiceTest {
                 "name": "Mount Everest",
                 "lat": "27.988056",
                 "lon": "86.925278",
-                "ellipseHeight": "8848.86",
+                "ellipHeight": "8848.86",
                 "posDatum": "N/A",
                 "posSource": "N/A",
                 "posOrder": "N/A",
-                "orthoHeight": "N/A",
+                "orthoHt": "N/A",
                 "vertDatum": "N/A",
                 "vertSource": "N/A",
                 "vertOrder": "N/A"
@@ -48,11 +48,11 @@ class BenchmarkServiceTest {
         assertEquals("Mount Everest", benchmark.name)
         assertEquals("27.988056", benchmark.lat)
         assertEquals("86.925278", benchmark.lon)
-        assertEquals("8848.86", benchmark.ellipseHeight)
+        assertEquals("8848.86", benchmark.ellipHeight)
         assertEquals("N/A", benchmark.posDatum)
         assertEquals("N/A", benchmark.posSource)
         assertEquals("N/A", benchmark.posOrder)
-        assertEquals("N/A", benchmark.orthoHeight)
+        assertEquals("N/A", benchmark.orthoHt)
         assertEquals("N/A", benchmark.vertDatum)
         assertEquals("N/A", benchmark.vertSource)
         assertEquals("N/A", benchmark.vertOrder)
@@ -65,11 +65,11 @@ class BenchmarkServiceTest {
                 name = "Mount Everest",
                 lat = "27.988056",
                 lon = "86.925278",
-                ellipseHeight = "8848.86",
+                ellipHeight = "8848.86",
                 posDatum = "N/A",
                 posSource = "N/A",
                 posOrder = "N/A",
-                orthoHeight = "N/A",
+                orthoHt = "N/A",
                 vertDatum = "N/A",
                 vertSource = "N/A",
                 vertOrder = "N/A"


### PR DESCRIPTION
@Emiller321 I kept the variables the same as the API so that it can sync between the API and our app. I appreciate the initiative though